### PR TITLE
Use configuration for DB context

### DIFF
--- a/la-mia-pizzeria-crud-mvc/Database/PizzeriaContext.cs
+++ b/la-mia-pizzeria-crud-mvc/Database/PizzeriaContext.cs
@@ -7,16 +7,25 @@ namespace la_mia_pizzeria_crud_mvc.Database
 {
     public class PizzeriaContext : IdentityDbContext<IdentityUser>
     {
+        private readonly IConfiguration _configuration;
+
         public DbSet<Pizza> Pizzas { get; set; }
 
         public DbSet<PizzaCategory> PizzaCategories { get; set; }
 
         public DbSet<Ingredient> Ingredients { get; set; }
 
+        public PizzeriaContext(DbContextOptions<PizzeriaContext> options, IConfiguration configuration) : base(options)
+        {
+            _configuration = configuration;
+        }
+
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseSqlServer("Data Source=localhost;Initial Catalog=MVCEFPizzeria;" +
-            "Integrated Security=True;TrustServerCertificate=True");
+            if (!optionsBuilder.IsConfigured)
+            {
+                optionsBuilder.UseSqlServer(_configuration.GetConnectionString("PizzeriaContextConnection"));
+            }
         }
 
     }

--- a/la-mia-pizzeria-crud-mvc/Program.cs
+++ b/la-mia-pizzeria-crud-mvc/Program.cs
@@ -15,7 +15,8 @@ namespace la_mia_pizzeria_crud_mvc
             var builder = WebApplication.CreateBuilder(args);
             var connectionString = builder.Configuration.GetConnectionString("PizzeriaContextConnection") ?? throw new InvalidOperationException("Connection string 'PizzeriaContextConnection' not found.");
 
-            builder.Services.AddDbContext<PizzeriaContext>();
+            builder.Services.AddDbContext<PizzeriaContext>(options =>
+                options.UseSqlServer(connectionString));
 
             builder.Services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = true)
                 .AddRoles<IdentityRole>()


### PR DESCRIPTION
## Summary
- fetch connection string from config in `PizzeriaContext`
- configure `PizzeriaContext` with `AddDbContext` using the connection string

## Testing
- `dotnet build la-mia-pizzeria-crud-mvc/la-mia-pizzeria-crud-mvc.csproj -clp:ErrorsOnly` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840199c4ed0832389c0ab1308e4501e